### PR TITLE
[Org Update] Update .NET to net8.0,net9.0,net10.0

### DIFF
--- a/dotnet-update-report.json
+++ b/dotnet-update-report.json
@@ -1,21 +1,22 @@
 {
-  "ChangeSummaryText": "No package version changes - packages may already be up to date",
-  "PackagesFound": 1,
   "TargetFrameworks": [
     "net8.0",
     "net9.0",
     "net10.0"
   ],
+  "Timestamp": "2025-11-17 06:14:42",
+  "ChangeSummaryText": "No package version changes - packages may already be up to date",
+  "PackagesFound": 1,
+  "ProjectsFound": 3,
   "Summary": {
-    "FrameworksSet": "net8.0;net9.0;net10.0",
-    "PackagesChanged": 0,
-    "ProjectsUpdated": 3,
-    "DirectoryPackagesPropsUpdated": true,
     "CommonPackages": 0,
     "FrameworkSpecificPackages": 1,
-    "PackagesConfigured": 1
+    "DirectoryPackagesPropsUpdated": true,
+    "PreservedPrivateAssets": 0,
+    "PackagesConfigured": 1,
+    "FrameworksSet": "net8.0;net9.0;net10.0",
+    "ProjectsUpdated": 3,
+    "PackagesChanged": 0
   },
-  "Timestamp": "2025-11-17 05:24:25",
-  "ProjectsFound": 3,
   "PackageChanges": []
 }


### PR DESCRIPTION
### Organization-Wide .NET Update

This PR was created as part of an organization-wide .NET update.

**Target Frameworks:** `net8.0,net9.0,net10.0`

**Tracking Issue:** https://github.com/Zonit/.github/issues/25

---

#### What Changed:
- **Projects Updated:** 3
- **Packages Configured:** 1
- **Package Versions Changed:** 0
- **Common Packages:** COMMON_1
- **Framework-Specific Packages:** 1
- **Target Frameworks:** `net8.0;net9.0;net10.0`
- **Central Package Management:** Enabled


**No package version changes** - packages may have been newly configured

---

**Next Steps:**
1. Review changes
2. Run `dotnet restore`
3. Run `dotnet build`
4. Run tests
5. Merge when ready

**Part of:** Organization-wide .NET update
**Tracking:** https://github.com/Zonit/.github/issues/25
